### PR TITLE
Change literals to convert degrees into radians

### DIFF
--- a/include/geo/rad_deg.h
+++ b/include/geo/rad_deg.h
@@ -7,7 +7,8 @@ namespace geo {
 constexpr double to_rad(double const deg) { return deg * kPI / 180.0; }
 constexpr double to_deg(double const rad) { return rad * 180.0 / kPI; }
 
-inline double operator""_rad(long double const deg) { return to_rad(static_cast<double>(deg)); }
-inline double operator""_deg(long double const rad) { return to_deg(static_cast<double>(rad)); }
+inline double operator""_deg(long double const deg) {
+  return to_rad(static_cast<double>(deg));
+}
 
 }  // namespace geo

--- a/include/geo/rad_deg.h
+++ b/include/geo/rad_deg.h
@@ -7,8 +7,4 @@ namespace geo {
 constexpr double to_rad(double const deg) { return deg * kPI / 180.0; }
 constexpr double to_deg(double const rad) { return rad * 180.0 / kPI; }
 
-inline double operator""_deg(long double const deg) {
-  return to_rad(static_cast<double>(deg));
-}
-
 }  // namespace geo

--- a/src/latlng.cc
+++ b/src/latlng.cc
@@ -114,13 +114,13 @@ latlng closest_on_segment(latlng const& x, latlng const& segment_from,
 
   assert(!std::isnan(start_angle) && !std::isnan(end_angle));
 
-  if (start_angle >= 90.0_deg) {
+  if (start_angle >= to_rad(90.0)) {
     return segment_from;
-  } else if (end_angle <= 90.0_deg) {
+  } else if (end_angle <= to_rad(90.0)) {
     return segment_to;
   } else {
     // law of sines
-    auto const beta = 90.0_deg - start_angle;
+    auto const beta = to_rad(90.0) - start_angle;
     auto const seg_offset = start_vec.length() * std::sin(beta);
     return merc_to_latlng(merc_from + seg_offset * seg_dir.normalize());
   }

--- a/src/latlng.cc
+++ b/src/latlng.cc
@@ -114,13 +114,13 @@ latlng closest_on_segment(latlng const& x, latlng const& segment_from,
 
   assert(!std::isnan(start_angle) && !std::isnan(end_angle));
 
-  if (start_angle >= 90.0_rad) {
+  if (start_angle >= 90.0_deg) {
     return segment_from;
-  } else if (end_angle <= 90.0_rad) {
+  } else if (end_angle <= 90.0_deg) {
     return segment_to;
   } else {
     // law of sines
-    auto const beta = 90.0_rad - start_angle;
+    auto const beta = 90.0_deg - start_angle;
     auto const seg_offset = start_vec.length() * std::sin(beta);
     return merc_to_latlng(merc_from + seg_offset * seg_dir.normalize());
   }

--- a/test/latlng_test.cc
+++ b/test/latlng_test.cc
@@ -7,7 +7,8 @@ TEST_CASE("destination_point") {
   auto constexpr distance1 = 111800.0;
   auto constexpr bearing1 = 0.0;
   auto constexpr destination1_exp = geo::latlng{41.00555556, -20.0};
-  auto const destination1_act = geo::destination_point(source1, distance1, bearing1);
+  auto const destination1_act =
+      geo::destination_point(source1, distance1, bearing1);
   CHECK(destination1_act.lat_ == doctest::Approx(destination1_exp.lat_));
   CHECK(destination1_act.lng_ == doctest::Approx(destination1_exp.lng_));
 
@@ -15,7 +16,8 @@ TEST_CASE("destination_point") {
   auto constexpr distance2 = 2342000.0;
   auto constexpr bearing2 = 90.0;
   auto constexpr destination2_exp = geo::latlng{-21.38472222, 64.70277777};
-  auto const destination2_act = geo::destination_point(source2, distance2, bearing2);
+  auto const destination2_act =
+      geo::destination_point(source2, distance2, bearing2);
   CHECK(destination2_act.lat_ == doctest::Approx(destination2_exp.lat_));
   CHECK(destination2_act.lng_ == doctest::Approx(destination2_exp.lng_));
 
@@ -23,7 +25,8 @@ TEST_CASE("destination_point") {
   auto constexpr distance3 = 11111000.0;
   auto constexpr bearing3 = 77.0;
   auto constexpr destination3_exp = geo::latlng{-9.69722222, 106.16833333};
-  auto const destination3_act = geo::destination_point(source3, distance3, bearing3);
+  auto const destination3_act =
+      geo::destination_point(source3, distance3, bearing3);
   CHECK(destination3_act.lat_ == doctest::Approx(destination3_exp.lat_));
   CHECK(destination3_act.lng_ == doctest::Approx(destination3_exp.lng_));
 }


### PR DESCRIPTION
This change removes the `_rad` literal and uses `_deg` for degrees to radians conversion.
As all calculations use radians, a literal for radians to degrees conversion is probably hardly useful. Instead `_rad` might later be used to create radians, which are no longer raw `double` values.