### PR TITLE
Fix computation for closest coordinate of segment

### DIFF
--- a/src/latlng.cc
+++ b/src/latlng.cc
@@ -74,6 +74,18 @@ uint32_t tile_hash_32(latlng const& pos) {
   return hash;
 }
 
+inline double get_rel(merc_xy const& v, merc_xy const& seg_dir,
+                      double const seg_len) {
+  return seg_dir.dot(v) / (seg_len * v.length());
+}
+
+inline double get_angle(double const x) {
+  if (x >= 1 - kEpsilon) {
+    return 0;
+  }
+  return std::acos(x);
+}
+
 latlng closest_on_segment(latlng const& x, latlng const& segment_from,
                           latlng const& segment_to) {
   auto const merc_x = latlng_to_merc(x);
@@ -92,38 +104,32 @@ latlng closest_on_segment(latlng const& x, latlng const& segment_from,
   }
 
   auto const start_vec = merc_x - merc_from;
-  auto const end_vec = merc_x - merc_to;
+  auto const end_vec = merc_to - merc_x;
 
-  auto const start_rel =
-      seg_dir.dot(start_vec) / (seg_len * start_vec.length());
-  if (start_rel >= 1 - kEpsilon) {
+  auto start_rel = get_rel(start_vec, seg_dir, seg_len);
+  if (start_rel <= -1 + kEpsilon) {
     return segment_from;
-  } else if (start_rel <= -1 + kEpsilon) {
+  }
+  auto end_rel = get_rel(end_vec, seg_dir, seg_len);
+  if (end_rel <= -1 + kEpsilon) {
     return segment_to;
   }
 
-  auto const end_rel = seg_dir.dot(end_vec) / (seg_len * end_vec.length());
-  if (end_rel >= 1 - kEpsilon) {
-    return segment_to;
-  } else if (end_rel <= -1 + kEpsilon) {
-    return segment_from;
-  }
-
-  auto const start_angle = std::acos(start_rel);
-  auto const end_angle = std::acos(end_rel);
-
-  assert(!std::isnan(start_angle) && !std::isnan(end_angle));
-
+  auto const start_angle = get_angle(start_rel);
+  assert(!std::isnan(start_angle));
   if (start_angle >= to_rad(90.0)) {
     return segment_from;
-  } else if (end_angle <= to_rad(90.0)) {
-    return segment_to;
-  } else {
-    // law of sines
-    auto const beta = to_rad(90.0) - start_angle;
-    auto const seg_offset = start_vec.length() * std::sin(beta);
-    return merc_to_latlng(merc_from + seg_offset * seg_dir.normalize());
   }
+  auto const end_angle = get_angle(end_rel);
+  assert(!std::isnan(end_angle));
+  if (end_angle >= to_rad(90.0)) {
+    return segment_to;
+  }
+
+  // law of sines
+  auto const beta = to_rad(90.0) - start_angle;
+  auto const seg_offset = start_vec.length() * std::sin(beta);
+  return merc_to_latlng(merc_from + seg_offset * seg_dir.normalize());
 }
 
 // Destination point given distance and bearing from start point

--- a/test/latlng_test.cc
+++ b/test/latlng_test.cc
@@ -1,5 +1,8 @@
 #include "doctest/doctest.h"
 
+#include <array>
+#include <vector>
+
 #include "geo/latlng.h"
 
 TEST_CASE("destination_point") {
@@ -29,4 +32,68 @@ TEST_CASE("destination_point") {
       geo::destination_point(source3, distance3, bearing3);
   CHECK(destination3_act.lat_ == doctest::Approx(destination3_exp.lat_));
   CHECK(destination3_act.lng_ == doctest::Approx(destination3_exp.lng_));
+}
+
+TEST_CASE("latlngClosestOnSegment_pointsNotOnSegment_getStartOrEnd") {
+  auto const tests =
+      std::vector<std::tuple<geo::latlng, geo::latlng, geo::latlng, bool>>{
+          // simple coordinates near start
+          {{0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}, true},
+          {{0.0, 0.0}, {1.0, 0.0}, {0.0, -1.0}, true},
+          {{0.0, 0.0}, {1.0, 0.0}, {-1.0, 0.0}, true},
+          {{0.0, 0.0}, {1.0, 0.0}, {-0.5, 0.5}, true},
+          // simple coordinates near end
+          {{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, false},
+          {{0.0, 0.0}, {1.0, 0.0}, {1.0, -1.0}, false},
+          {{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, false},
+          {{0.0, 0.0}, {1.0, 0.0}, {1.5, 0.5}, false},
+          // larger distances
+          {{50.0, 0.0}, {90.0, 180.0}, {39.0, 10.0}, true},
+          {{0.0, 0.0}, {0.0, 90.0}, {0.0, 120.0}, false},
+          // random coordinates
+          {{24.427, -163.318}, {46.629, -85.595}, {83.911, -7.324}, false},
+          {{-54.556, 66.671}, {-68.925, -70.823}, {36.411, 97.435}, true},
+          {{-12.087, 53.036}, {-63.395, -104.788}, {-15.509, -137.375}, false},
+          {{48.384, 3.970}, {-86.712, -147.266}, {66.293, 3.294}, true},
+          {{-26.293, 83.294}, {63.181, -44.492}, {10.135, -159.263}, false},
+          // (random) coordinates in Europe
+          {{35.700, 17.598}, {57.153, 28.220}, {65.793, 36.753}, false},
+          {{48.507, 17.041}, {37.068, 48.912}, {53.585, 1.913}, true},
+      };
+  for (auto const& [from, to, x, is_start] : tests) {
+    auto const closest = geo::closest_on_segment(x, from, to);
+
+    auto const& expected = is_start ? from : to;
+    CHECK(expected == closest);
+  }
+}
+
+TEST_CASE(
+    "latlngClosestOnSegment_pointsCloseToSegment_getReasonableCandidate") {
+  auto const tests = std::vector<std::array<geo::latlng, 3>>{
+      // simple coordinates
+      {{{0.0, 0.0}, {1.0, 0.0}, {0.1, 0.0}}},
+      {{{0.0, 0.0}, {1.0, 0.0}, {0.9, 0.0}}},
+      {{{0.0, 0.0}, {1.0, 0.0}, {0.5, 0.0}}},
+      {{{0.0, 0.0}, {1.0, 0.0}, {0.5, 0.2}}},
+      // close to segment
+      {{{-59.0, 54.0}, {-67.0, 26.0}, {-62.7, 42.0}}},
+      {{{1.0, 1.0}, {1.0020, 1.0005}, {1.0010, 1.0011}}},
+      // (random) coordinates in Europe
+      {{{37.3908, 8.3000}, {67.8311, 39.7556}, {41.4347, 27.7353}}},
+      {{{37.2922, 25.0194}, {57.9814, 5.5728}, {50.6969, 5.3486}}},
+      {{{40.303, 45.234}, {46.657, 15.126}, {34.561, 41.347}}},
+      {{{36.377, 25.299}, {48.428, 39.082}, {43.046, 24.722}}},
+      {{{49.885, 22.146}, {70.732, 29.241}, {61.708, 8.514}}},
+      {{{37.864, 38.041}, {50.021, 7.588}, {41.093, 8.343}}},
+      {{{49.660, -5.444}, {66.286, 48.260}, {41.630, 9.008}}},
+  };
+  for (auto const& [from, to, x] : tests) {
+    auto const closest = geo::closest_on_segment(x, from, to);
+
+    CHECK(!(closest == from));
+    CHECK(!(closest == to));
+    CHECK(geo::distance(x, closest) < geo::distance(x, from));
+    CHECK(geo::distance(x, closest) < geo::distance(x, to));
+  }
 }


### PR DESCRIPTION
This fixes an issue, where the algorithm returned the starting point of a segment, if the given coordinate was located on or close to the segment.