### PR TITLE
Fix bearing() to return standard CW-from-north degrees

### DIFF
--- a/src/latlng.cc
+++ b/src/latlng.cc
@@ -39,9 +39,10 @@ double approx_squared_distance(latlng const& a, latlng const& b,
   return x * x + y * y;
 }
 
-// following non-public boost implementation
+// Initial bearing (CW from north) from p1 to p2.
+// http://www.movable-type.co.uk/scripts/latlong.html
 double bearing(latlng const& p1, latlng const& p2) {
-  double dlng = to_rad(p1.lng_) - to_rad(p2.lng_);  // CCW from NORTH!
+  double dlng = to_rad(p2.lng_) - to_rad(p1.lng_);
   double cos_p2lat = std::cos(to_rad(p2.lat_));
 
   auto bearing =
@@ -49,7 +50,7 @@ double bearing(latlng const& p1, latlng const& p2) {
                  std::cos(to_rad(p1.lat_)) * std::sin(to_rad(p2.lat_)) -
                      std::sin(to_rad(p1.lat_)) * cos_p2lat * std::cos(dlng));
 
-  return to_deg(std::fmod(bearing, 2 * kPI));
+  return to_deg(std::fmod(bearing + 2 * kPI, 2 * kPI));
 }
 
 // https://stackoverflow.com/a/4656937/10794188

--- a/test/latlng_test.cc
+++ b/test/latlng_test.cc
@@ -5,6 +5,29 @@
 
 #include "geo/latlng.h"
 
+TEST_CASE("bearing_returns_cw_from_north") {
+  CHECK(geo::bearing({0.0, 0.0}, {10.0, 0.0}) == doctest::Approx(0.0));
+  CHECK(geo::bearing({0.0, 0.0}, {0.0, 10.0}) == doctest::Approx(90.0));
+  CHECK(geo::bearing({10.0, 0.0}, {0.0, 0.0}) == doctest::Approx(180.0));
+  CHECK(geo::bearing({0.0, 0.0}, {0.0, -10.0}) == doctest::Approx(270.0));
+}
+
+TEST_CASE("bearing_known_cities") {
+  // London (51.5074 N, 0.1278 W) to Paris (48.8566 N, 2.3522 E)
+  // Paris is southeast of London — expected bearing ~150° (between 90° and 180°)
+  auto const london = geo::latlng{51.5074, -0.1278};
+  auto const paris = geo::latlng{48.8566, 2.3522};
+  auto const b = geo::bearing(london, paris);
+  CHECK(b > 90.0);
+  CHECK(b < 180.0);
+
+  // Roundtrip: bearing + destination_point should recover the target
+  auto const dist = geo::distance(london, paris);
+  auto const recovered = geo::destination_point(london, dist, b);
+  CHECK(recovered.lat_ == doctest::Approx(paris.lat_).epsilon(0.01));
+  CHECK(recovered.lng_ == doctest::Approx(paris.lng_).epsilon(0.01));
+}
+
 TEST_CASE("destination_point") {
   auto constexpr source1 = geo::latlng{40.0, -20.0};
   auto constexpr distance1 = 111800.0;


### PR DESCRIPTION
Hello!
I was playing with the geo library for a bit and found it was giving unexpected bearings for me. I found that it was actually giving me counter-clockwise values. The comment there was clearly indicating that but that's not standard and easily breaks assumptions of users of the library.
Another smaller issue is that the output wasn't properly normalized to [0, 360) but was rather in the [-180, 180] range.